### PR TITLE
Support using system ffmpeg

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
+    "@types/which": "^2.0.1",
     "async": "^3.2.4",
     "axios": "^0.27.2",
     "better-sqlite3": "^7.6.2",
     "cli-progress": "^3.11.2",
     "fs-extra": "^10.1.0",
     "inquirer": "^9.1.2",
-    "m3u8-parser": "^6.0.0"
+    "m3u8-parser": "^6.0.0",
+    "which": "^3.0.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,7 +252,7 @@ async function downloadSeries(hidiveDao: HidiveDao) {
         const tempEpisodePath = fileManager.getTempPath(`${episodeFileName}.mkv`)
         const episodePath = fileManager.getOutputPath(`${episodeFileName}.mkv`)
 
-        const ffmpegConvertVideoProcess = ffmpeg.convertVideo(tempEpisodePath)
+        const ffmpegConvertVideoProcess = await ffmpeg.convertVideo(tempEpisodePath)
 
         const bar = multiBar.create(mediasRes.segments.length, 0, { download: 0, episode: `${selectedSeries.Name} - ${episode.Name}` })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/which@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.1.tgz#27ecd67f915b7c3d6ba552135bb1eecd66e63501"
+  integrity sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==
+
 "@videojs/vhs-utils@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz#665ba70d78258ba1ab977364e2fe9f4d4799c46c"
@@ -475,6 +480,11 @@ is-unicode-supported@^1.1.0, is-unicode-supported@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
   integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -864,6 +874,13 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+which@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-3.0.0.tgz#a9efd016db59728758a390d23f1687b6e8f59f8e"
+  integrity sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==
+  dependencies:
+    isexe "^2.0.0"
 
 wrap-ansi@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
I'm using the downloader on macOS, so I had to make modifications to allow it to work. Instead of just hardcoding for my use case, I decided to update the project to attempt to look for ffmpeg in the path, before falling back to the hardcoded path.

A future enhancement could be to support a project like [ffmpeg-static][], and allow the user to pick between the static install, or the system install. (Or even just specify a path.)

[ffmpeg-static]: https://www.npmjs.com/package/ffmpeg-static